### PR TITLE
Center CTA buttons and adjust banner styles

### DIFF
--- a/src/app/_components/sections/CallToAction.jsx
+++ b/src/app/_components/sections/CallToAction.jsx
@@ -19,11 +19,11 @@ const CallToActionSection = () => {
                                                                 <div className="tst-fade-up">
                                                                         <div className="tst-text tst-text-lg tst-text-shadow tst-white-2" dangerouslySetInnerHTML={{__html : Data.description}} />
                                                                 </div>
-                                                                <a href={Data.button1.link} target="_blank" className="tst-btn tst-btn-lg tst-btn-shadow tst-mt-30 tst-mr-10 tst-fade-up">
+                                                                <a href={Data.button1.link} style={{marginLeft: 'auto', marginRight: 'auto'}} target="_blank" className="tst-btn tst-btn-lg tst-btn-shadow tst-mt-30 tst-mr-10 tst-fade-up">
                                                                         <i className={Data.button1.icon}></i> 
                                                                         {Data.button1.label}
                                                                 </a>
-                                                                <a href={Data.button2.link} target="_blank" className="tst-btn tst-btn-lg tst-btn-shadow tst-mt-30 tst-fade-up">
+                                                                <a href={Data.button2.link} style={{marginLeft: 'auto', marginRight: 'auto'}} target="_blank" className="tst-btn tst-btn-lg tst-btn-shadow tst-mt-30 tst-fade-up">
                                                                         <i className={Data.button2.icon}></i> 
                                                                         {Data.button2.label}
                                                                 </a>

--- a/src/app/_components/sections/CallToActionFour.jsx
+++ b/src/app/_components/sections/CallToActionFour.jsx
@@ -21,8 +21,8 @@ const CallToActionFourSection = () => {
                     <div className="tst-fade-up tst-mb-30">
                         <div className="tst-text tst-text-lg tst-text-shadow tst-white-2" dangerouslySetInnerHTML={{__html : Data.description}} />
                     </div>
-                    <Link href={Data.button1.link} className="tst-btn tst-btn-lg tst-btn-shadow tst-fade-up tst-res-btn tst-mr-30">{Data.button1.label}</Link>
-                    <Link href={Data.button2.link} className="tst-label tst-anima-link tst-white-2 tst-fade-up">{Data.button2.label}</Link>
+                    <Link href={Data.button1.link} style={{marginLeft: 'auto', marginRight: 'auto'}} className="tst-btn tst-btn-lg tst-btn-shadow tst-fade-up tst-res-btn tst-mr-30">{Data.button1.label}</Link>
+                    <Link href={Data.button2.link} style={{marginLeft: 'auto', marginRight: 'auto'}} className="tst-label tst-anima-link tst-white-2 tst-fade-up">{Data.button2.label}</Link>
                     </div>
                 </div>
                 {/* text end */}

--- a/src/app/_components/sections/CallToActionThree.jsx
+++ b/src/app/_components/sections/CallToActionThree.jsx
@@ -40,7 +40,7 @@ const CallToActionThreeSection = () => {
                         <div className="tst-fade-up">
                             <div className="tst-text tst-text-lg tst-text-shadow tst-white-2 tst-mb-30" dangerouslySetInnerHTML={{__html : Data.description}} />
                         </div>
-                        <Link href={Data.button.link} className="tst-btn tst-btn-lg tst-btn-shadow tst-res-btn tst-fade-up tst-mr-30 dark">{Data.button.label}</Link>
+                        <Link href={Data.button.link} style={{marginLeft: 'auto', marginRight: 'auto'}} className="tst-btn tst-btn-lg tst-btn-shadow tst-res-btn tst-fade-up tst-mr-30 dark">{Data.button.label}</Link>
                         </div>
                     </div>
                     {/* text end */}

--- a/src/app/_components/sections/CallToActionTwo.jsx
+++ b/src/app/_components/sections/CallToActionTwo.jsx
@@ -20,8 +20,8 @@ const CallToActionTwoSection = () => {
                     <div className="tst-fade-up">
                         <div className="tst-text tst-text-lg tst-text-shadow tst-white-2 tst-mb-30" dangerouslySetInnerHTML={{__html : Data.description}} />
                     </div>
-                    <a href={Data.button1.link} className="tst-btn tst-btn-lg tst-btn-shadow tst-anima-link tst-fade-up tst-mr-30 dark">{Data.button1.label}</a>
-                    <a href={Data.button2.link} className="tst-label tst-white-2 tst-fade-up dark">{Data.button2.label}</a>
+                    <a href={Data.button1.link} style={{marginLeft: 'auto', marginRight: 'auto'}} className="tst-btn tst-btn-lg tst-btn-shadow tst-anima-link tst-fade-up tst-mr-30 dark">{Data.button1.label}</a>
+                    <a href={Data.button2.link} style={{marginLeft: 'auto', marginRight: 'auto'}} className="tst-label tst-white-2 tst-fade-up dark">{Data.button2.label}</a>
                     </div>
                 </div>
                 {/* text end */}

--- a/src/app/_styles/scss/_content.scss
+++ b/src/app/_styles/scss/_content.scss
@@ -117,7 +117,7 @@ banner
 		height: 100%;
 		display: flex;
 		justify-content: center;
-		align-items: center;
+		// align-items: center;
 
 		&.tst-with-map {
 			pointer-events: none;
@@ -171,7 +171,7 @@ banner
 			padding: 90px 0;
 			height: 100%;
 			display: flex;
-			align-items: center;
+			// align-items: center;
 
 			& .tst-main-title-frame {
 				height: auto;

--- a/src/app/_styles/scss/_custom.scss
+++ b/src/app/_styles/scss/_custom.scss
@@ -118,7 +118,11 @@ body .tst-slider-navigation .tst-slider-pagination {
 
 @media (max-width: 767px) {
 	.tst-dynamic-banner {min-height: 300px;
-  max-height: 65vh;
+  // max-height: 65vh;
+  }
+
+  .tst-cta-icon-wrapper {
+    padding: 1em !important;
   }
 }
 


### PR DESCRIPTION
Added inline styles to center call-to-action buttons in multiple section components. Commented out 'align-items: center' in banner SCSS to allow more flexible vertical alignment. Updated custom SCSS for mobile to remove max-height restriction on dynamic banners and add padding to CTA icon wrapper.